### PR TITLE
Feature/s3 file copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Ignore Folders
 config/aws.*
 coverage/**
+log/**

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The basic command line execution statement to access any s3 operation begins wit
 bin/s3_store_server <operation-name> <list-of-required-params-for-operation>
 ```
 
+### Usage:
+
 * #### Bucket Operations
 
 1. **List Buckets** - This will list out all the buckets in your aws s3 account. 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ bin/s3_store_server delete <bucket-name>
 * #### Object Operations
 
 1. Copy Object
+
 Copy operation deals with being able to copy files and s3 objects. 
 This feature handles 4 scenarios - 
 

--- a/README.md
+++ b/README.md
@@ -52,18 +52,25 @@ All methods used are provided by the aws-sdk-s3 gem for v3.
 
 Each scenario works as explained below - 
 
-1. **Copy from one s3 bucket to another s3 bucket** - While copying objects from one bucket to another, s3_store uses the `copy_object` method. It requires the _source bucket name, destination bucket name_ and _key._
+1. **Copy from one s3 bucket to another s3 bucket** - While copying objects from one bucket to another, s3_store uses the `copy_object` method. It requires the _source-s3-object-uri, destination-bucket-uri_.
 
 Command Line example - 
 ```
-bin/s3_store_server copy <source-bucket> key:<key-name> source:<source-file-name> destination:<destination-bucket>                         
+bin/s3_store_server copy s3://<uri-path-to-object> s3://<destination-bucket>
 ```
 
-2. **Copy from local to s3 bucket - upload** - While copying objects from local to s3 bucket, s3_store uses the `upload_file` method. It requires the _source file path, destination bucket name_ and _key_.
+2. **Copy from local to s3 bucket - upload** - While copying objects from local to s3 bucket, s3_store uses the `upload_file` method. It requires the _source-file-path, destination-bucket-uri_.
 
 Command Line example - 
 ```
-bin/s3_store_server copy <destination-bucket> key:<key-name> source:<full-path-to-local-file> destination:<destination-bucket>
+bin/s3_store_server copy local-file-path s3://<destination-bucket>
+```
+
+3. **Copy from s3 bucket to local- download** - While copying objects from s3 bucket to local, s3_store uses the `get_object` method. It requires the _s3-object-uri _destination-file-path_.
+
+Command Line example - 
+```
+bin/s3_store_server copy s3://<source-obj-uri> local-file-path/<filename>
 ```
 
 4. **Copy from local to local - not supported** - While copying objects from local to local, s3_store will raise an error `S3ObjectOperationError`. 

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ Each scenario works as explained below -
 
 Command Line example - 
 ```
-bin/s3_store_server copy bucket-1 key:"file_2" source:"file_1" destination:"bucket-2"                         
+bin/s3_store_server copy <source-bucket> key:<key-name> source:<source-file-name> destination:<destination-bucket>                         
 ```
 
 2. **Copy from local to s3 bucket - upload** - While copying objects from local to s3 bucket, s3_store uses the `upload_file` method. It requires the _source file path, destination bucket name_ and _key_.
 
 Command Line example - 
 ```
-bin/s3_store_server copy bucket-1 key:<key_name> source:<full_path_to_local_file> destination:bucket-1
+bin/s3_store_server copy <destination-bucket> key:<key-name> source:<full-path-to-local-file> destination:<destination-bucket>
 ```
 
 4. **Copy from local to local - not supported** - While copying objects from local to local, s3_store will raise an error `S3ObjectOperationError`. 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
 # s3_store
-Framework for using AWS S3 buckets for storage.
+s3_store is a console based simple Ruby application which enables you to perform operations on your s3 buckets and objects using `aws-sdk` gem v3.
+
+Operations on s3 buckets include creating, deleting and listing buckets.
+
+Operations on s3 objects include copying and deleting objects.
+
+The basic command line execution statement to access any s3 operation begins with...
+
+```
+bin/s3_store_server <operation-name> <list-of-required-params-for-operation>
+```
+
+* #### Bucket Operations
+
+1. **List Buckets** - This will list out all the buckets in your aws s3 account. 
+
+Command Line statement - 
+```
+bin/s3_store_server list
+```
+
+2. **Create Bucket** - This will create a new bucket from the bucket name provided.
+
+Command Line statement - 
+```
+bin/s3_store_server create <bucket-name>
+```
+
+3. **Delete Bucket** - This will delete an existing bucket from the name provided.
+
+Command Line statement - 
+```
+bin/s3_store_server delete <bucket-name>
+```
+
+* #### Object Operations
+
+1. Copy Object
+Copy operation deals with being able to copy files and s3 objects. 
+This feature handles 4 scenarios - 
+
+1. Copy from one s3 bucket to another s3 bucket - Copy
+2. Copy from local to s3 bucket - upload
+3. Copy from s3 bucket to local - download
+4. Copy from local to local - local copy
+
+All methods used are provided by the aws-sdk-s3 gem for v3.
+
+Each scenario works as explained below - 
+
+1. **Copy from one s3 bucket to another s3 bucket** - While copying objects from one bucket to another, s3_store uses the `copy_object` method. It requires the _source bucket name, destination bucket name_ and _key._
+
+Command Line example - 
+```
+bin/s3_store_server copy bucket-1 key:"file_2" source:"file_1" destination:"bucket-2"                         
+```
+
+2. **Copy from local to s3 bucket - upload** - While copying objects from local to s3 bucket, s3_store uses the `upload_file` method. It requires the _source file path, destination bucket name_ and _key_.
+
+Command Line example - 
+```
+bin/s3_store_server copy bucket-1 key:<key_name> source:<full_path_to_local_file> destination:bucket-1
+```
+
+4. **Copy from local to local - not supported** - While copying objects from local to local, s3_store will raise an error `S3ObjectOperationError`. 

--- a/application.rb
+++ b/application.rb
@@ -1,6 +1,6 @@
 class Application
 
-  attr_reader :client
+  attr_reader :client, :resource
   
   def initialize
     creds = Aws::Credentials.new(AwsLoader::AWS["access_key_id"], AwsLoader::AWS["secret_access_key"])

--- a/application.rb
+++ b/application.rb
@@ -5,6 +5,7 @@ class Application
   def initialize
     creds = Aws::Credentials.new(AwsLoader::AWS["access_key_id"], AwsLoader::AWS["secret_access_key"])
     @client = Aws::S3::Client.new(region: AwsLoader::AWS["region"], credentials: creds)
+    @resource = Aws::S3::Resource.new(region: AwsLoader::AWS["region"], credentials: creds)
   end
 
   @@root ||= Dir.pwd
@@ -15,7 +16,7 @@ class Application
     end
   
     def log
-        @@logger ||= Logger.new(File.join(@@root, 'log', 'q_it.log'))
+        @@logger ||= Logger.new(File.join(@@root, 'log', 's3_store.log'))
       end
 
       def generate_log_file

--- a/bin/app.rb
+++ b/bin/app.rb
@@ -21,12 +21,13 @@ class App
       s3_bucket.delete_bucket
     when 'list'
       store = Store.new
-      store.list_buckets
+      buckets = store.list_buckets
+      buckets.each { |name| puts name.colorize(:yellow) }
     when 'copy'
       raise S3StoreArgumentError, "S3StoreArgumentError:: insufficient arguments" if options.count != 4
 
       s3_obj = S3Object.new(bucket_name)
-      s3_obj.perform_operation(options = { operation: 'copy', source: options[1], destination: options[2], key: options[3] })
+      s3_obj.perform_operation(options = { operation: 'copy', params: [options[1], options[2], options[3]] })
     else
       raise S3StoreNoServiceError, "Invalid operation name. Try #{OPERATIONS.join(', ')}.".colorize(:red) if (operation.nil? || !OPERATIONS.include?(operation.downcase))
     end  

--- a/bin/app.rb
+++ b/bin/app.rb
@@ -22,6 +22,11 @@ class App
     when 'list'
       store = Store.new
       store.list_buckets
+    when 'copy'
+      raise S3StoreArgumentError, "S3StoreArgumentError:: insufficient arguments" if options.count != 4
+
+      s3_obj = S3Object.new(bucket_name)
+      s3_obj.perform_operation(options = { operation: 'copy', source: options[1], destination: options[2], key: options[3] })
     else
       raise S3StoreNoServiceError, "Invalid operation name. Try #{OPERATIONS.join(', ')}.".colorize(:red) if (operation.nil? || !OPERATIONS.include?(operation.downcase))
     end  
@@ -30,6 +35,7 @@ end
 
 # Beginning of execution of App.
 options = ARGV
+puts options
 raise S3StoreArgumentError, "Wrong Arguments. Check documentation on how to run the operation.".colorize(:red) if options.length < 1
 operation = options[0]
 

--- a/bin/s3_store_server
+++ b/bin/s3_store_server
@@ -4,6 +4,6 @@ if ARGV[1].nil?
   system("ruby", "bin/app.rb", ARGV[0])
 elsif ARGV[2].nil?
   system("ruby", "bin/app.rb", ARGV[0], ARGV[1])
-elsif ARGV.count == 5
-  system("ruby", "bin/app.rb", ARGV[0], ARGV[1], ARGV[2], ARGV[3], ARGV[4])
+else
+  system("ruby", "bin/app.rb", ARGV[0], ARGV[1], ARGV[2])
 end

--- a/bin/s3_store_server
+++ b/bin/s3_store_server
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 if ARGV[1].nil?
   system("ruby", "bin/app.rb", ARGV[0])
-else
+elsif ARGV[2].nil?
   system("ruby", "bin/app.rb", ARGV[0], ARGV[1])
+else
+  system("ruby", "bin/app.rb", ARGV[0], ARGV[1], ARGV[2], ARGV[3], ARGV[4])
 end

--- a/bin/s3_store_server
+++ b/bin/s3_store_server
@@ -1,9 +1,3 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
-if ARGV[1].nil?
-  system("ruby", "bin/app.rb", ARGV[0])
-elsif ARGV[2].nil?
-  system("ruby", "bin/app.rb", ARGV[0], ARGV[1])
-else
-  system("ruby", "bin/app.rb", ARGV[0], ARGV[1], ARGV[2])
-end
+system("ruby", "bin/app.rb", ARGV.join(' '))

--- a/bin/s3_store_server
+++ b/bin/s3_store_server
@@ -4,6 +4,6 @@ if ARGV[1].nil?
   system("ruby", "bin/app.rb", ARGV[0])
 elsif ARGV[2].nil?
   system("ruby", "bin/app.rb", ARGV[0], ARGV[1])
-else
+elsif ARGV.count == 5
   system("ruby", "bin/app.rb", ARGV[0], ARGV[1], ARGV[2], ARGV[3], ARGV[4])
 end

--- a/lib/bucket.rb
+++ b/lib/bucket.rb
@@ -1,6 +1,8 @@
 class Bucket
 
   attr_reader :bucket_name, :client
+
+  BUCKET_NAME_REGEX = /(?=^.{3,63}$)(?!^(\d+\.)+\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)/
   
   def initialize(name)
     @client = Application.new.client
@@ -8,8 +10,7 @@ class Bucket
   end
 
   def self.valid?(bucket_name)
-    regex = /(?=^.{3,63}$)(?!^(\d+\.)+\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)/
-    bucket_name.match?(regex)    
+    bucket_name.match?(BUCKET_NAME_REGEX)    
   end
 
   def delete_bucket
@@ -19,6 +20,8 @@ class Bucket
       puts "Bucket #{bucket_name} deleted successfully!".colorize(:green) unless response.nil?
     rescue Aws::S3::Errors::NoSuchBucket => e
       puts "Aws::S3::Errors::NoSuchBucket :: #{bucket_name} does not exist!".colorize(:red)
+    rescue Aws::S3::Errors::BucketNotEmpty => e
+      puts "Aws::S3::Errors::BucketNotEmpty :: #{bucket_name} is not empty!".colorize(:red)
     end
   end
 end

--- a/lib/s3_object.rb
+++ b/lib/s3_object.rb
@@ -53,11 +53,7 @@ class S3Object
   end
 
   def file_is_local?(file)
-    !valid_bucket_name?(file) 
-  end
-
-  def valid_bucket_name?(bucket)
-    Bucket.valid?(bucket)
+    !Bucket.valid?(file)
   end
 
   def object_exists?(object, bucket = self.bucket)

--- a/lib/s3_object.rb
+++ b/lib/s3_object.rb
@@ -1,0 +1,54 @@
+class S3Object
+
+  attr_accessor :bucket
+  attr_reader :aws_obj
+
+  FILEPATH_REGEX = /(\\\\?([^\\/]*[\\/])*)([^\\/]+)$/
+
+  def initialize(bucket)
+    @aws_obj = Application.new
+    @bucket = bucket
+  end
+
+  def copy(destination_bucket,filename)
+    begin
+      result = aws_obj.resource.copy_object(bucket: destination_bucket, copy_source: "#{bucket}/#{filename}", key: filename)
+      Application.log "Object copied from #{bucket} to #{destination_bucket} - #{result}"
+      puts "#{filename} copied successfully to #{destination_bucket}!".colorize(:green)
+    rescue Aws::S3::Errors::PermanentRedirect => e
+      handle_error(e)
+    end
+  end
+
+  def upload(filepath, key=nil)
+    begin
+      key = File.basename(filepath) if key.nil? || key.empty?
+      obj = aws_obj.resource.bucket(bucket).object(key)
+      if obj.upload_file(filepath)
+        Application.log "#{key} upload successful! :: #{obj}"
+        puts "File upload to #{bucket} successful!".colorize(:green)
+      else 
+        raise S3ObjectCopyError, "S3ObjectCopyError :: Unable to upload #{filepath}.".colorize(:red)
+      end
+    rescue Aws::S3::Errors::NoSuchBucket => e
+      handle_error(e)
+    rescue Aws::S3::Errors::PermanentRedirect => e
+      handle_error(e)
+    end
+  end
+
+  def download(key, destination_path)
+    begin
+      result = s3.get_object({ bucket: bucket, key:key }, target: destination_path)
+    rescue Aws::S3::Errors::PermanentRedirect => e
+      handle_error(e)
+    end
+  end
+
+  protected
+  
+  def handle_error(error)
+    Application.log(error)
+    puts "Error :: #{error}".colorize(:red)
+  end
+end

--- a/lib/s3_object.rb
+++ b/lib/s3_object.rb
@@ -64,23 +64,6 @@ class S3Object
     end
   end
 
-  protected
-  
-  def handle_error(error)
-    Application.log.error(error)
-    puts "Error :: #{error}".colorize(:red)
-  end
-
-  def sanitize_params(options={})
-    key, source, destination = "", "", ""
-    options[:params].each do |param|
-      key = param.split(':')[1] if param.match?(/key/)
-      source = param.split(':')[1] if param.match?(/source/)
-      destination = param.split(':')[1] if param.match?(/destination/)
-    end
-    { key: key, source: source, destination: destination }
-  end
-
   def invalid_file_options?(source, destination)
     !(source.match?(FILEPATH_REGEX) && destination.match?(FILEPATH_REGEX))
   end
@@ -98,7 +81,24 @@ class S3Object
   end
 
   def object_exists?(object)
-    bucket = aws_obj.resource.bucket(self.bucket)
+    bucket = aws_obj.resource.bucket(bucket)
     bucket.object(object).exists?
+  end
+
+  protected
+  
+  def handle_error(error)
+    Application.log.error(error)
+    puts "Error :: #{error}".colorize(:red)
+  end
+
+  def sanitize_params(options={})
+    key, source, destination = "", "", ""
+    options[:params].each do |param|
+      key = param.split(':')[1] if param.match?(/key/)
+      source = param.split(':')[1] if param.match?(/source/)
+      destination = param.split(':')[1] if param.match?(/destination/)
+    end
+    { key: key, source: source, destination: destination }
   end
 end

--- a/lib/s3_object.rb
+++ b/lib/s3_object.rb
@@ -45,10 +45,28 @@ class S3Object
     end
   end
 
+  def perform_operation(params={})
+    options = sanitize_params(params)
+    if options[:source].match?(FILEPATH_REGEX) && !options[:destination].match?(FILEPATH_REGEX)
+      upload(options[:source], options[:key])
+    elsif options[:destination].match?(FILEPATH_REGEX) && !options[:source].match?(FILEPATH_REGEX)
+      download(options[:key], options[:destination])
+    else
+      copy(options[:destination], options[:key])
+    end
+  end
+
   protected
   
   def handle_error(error)
     Application.log(error)
     puts "Error :: #{error}".colorize(:red)
+  end
+
+  def sanitize_params(options={})
+    key = options[:key].split(':')[1]
+    source = options[:source].split(':')[1]
+    destination = options[:destination].split(':')[1]
+    { key: key, source: source, destination: destination }
   end
 end

--- a/lib/s3_object.rb
+++ b/lib/s3_object.rb
@@ -3,7 +3,7 @@ class S3Object
   attr_accessor :bucket
   attr_reader :aws_obj
 
-  FILEPATH_REGEX = /(\\\\?([^\\/]*[\\/])*)([^\\/]+)$/
+  FILEPATH_REGEX = "(\\\\?([^\\/]*[\\/])*)([^\\/]+)$"
 
   def initialize(bucket)
     @aws_obj = Application.new

--- a/lib/s3_object.rb
+++ b/lib/s3_object.rb
@@ -1,7 +1,6 @@
 class S3Object
 
-  attr_accessor :bucket
-  attr_reader :aws_obj
+  attr_reader :aws_obj, :bucket
 
   FILEPATH_REGEX = "(\\\\?([^\\/]*[\\/])*)([^\\/]+)$"
 
@@ -10,31 +9,28 @@ class S3Object
     @bucket = bucket
   end
 
-  def copy(destination_bucket,filename)
-    aws_obj.client.copy_object(bucket: destination_bucket, copy_source: "#{bucket}/#{filename}", key: filename)
+  def copy(destination_bucket, key)
+    aws_obj.client.copy_object(bucket: destination_bucket, copy_source: "#{bucket}/#{key}", key: key)
   end
 
-  def upload(filepath, key=nil)
-    key = File.basename(filepath) if key.nil? || key.empty?
+  def upload(source_path, key=nil)
     obj = aws_obj.resource.bucket(bucket).object(key)
-    response = obj.upload_file(filepath)
-    raise S3ObjectCopyError, "S3ObjectCopyError :: Unable to upload #{filepath}.".colorize(:red) unless response
+    response = obj.upload_file(source_path)
+    raise S3ObjectCopyError, "S3ObjectCopyError :: Unable to upload #{source_path}.".colorize(:red) unless response
     response
   end
 
   def download(key, destination_path)
-    aws_obj.client.get_object({ bucket: bucket, key:key }, target: destination_path)
+    aws_obj.client.get_object({ bucket: bucket, key:key }, target: "#{destination_path}/#{key}")
   end
 
-  def perform_operation(params={})
-    options = sanitized_params(params)
-
-    raise S3ObjectOperationError, "S3ObjectOperationError :: Source or Destination or both files must belong to a S3 bucket." if invalid_file_options?(options[:source], options[:destination])
+  def perform_operation(options)
+    raise S3ObjectOperationError, "S3ObjectOperationError :: Source or Destination or both files must belong to a S3 bucket." if local_to_local?(options[:source], options[:destination])
 
     begin
       result = if file_is_local?(options[:source]) && !file_is_local?(options[:destination])
                 upload(options[:source], options[:key])
-              elsif file_is_local?(options[:destination]) && object_exists?(options[:source])
+              elsif file_is_local?(options[:destination]) && object_exists?(options[:key])
                 download(options[:key], options[:destination])
               else
                 copy(options[:destination], options[:key])
@@ -52,12 +48,12 @@ class S3Object
     end        
   end
 
-  def invalid_file_options?(source, destination)
-    !(source.match?(FILEPATH_REGEX) && destination.match?(FILEPATH_REGEX))
+  def local_to_local?(source, destination)
+    file_is_local?(source) && file_is_local?(destination)
   end
 
   def file_is_local?(file)
-    file.match?(FILEPATH_REGEX) && !valid_bucket_name?(file) && !object_exists?(file)
+    !valid_bucket_name?(file) 
   end
 
   def object_from_bucket?(file)

--- a/lib/s3_object.rb
+++ b/lib/s3_object.rb
@@ -56,10 +56,6 @@ class S3Object
     !valid_bucket_name?(file) 
   end
 
-  def object_from_bucket?(file)
-    !file.match?(FILEPATH_REGEX) && valid_bucket_name?(file)
-  end
-
   def valid_bucket_name?(bucket)
     Bucket.valid?(bucket)
   end
@@ -74,15 +70,5 @@ class S3Object
   def handle_error(error)
     Application.log.error(error)
     puts "Error :: #{error}".colorize(:red)
-  end
-
-  def sanitized_params(options={})
-    key, source, destination = "", "", ""
-    options[:params].each do |param|
-      key = param.split(':')[1] if param.match?(/key/)
-      source = param.split(':')[1] if param.match?(/source/)
-      destination = param.split(':')[1] if param.match?(/destination/)
-    end
-    { key: key, source: source, destination: destination }
   end
 end

--- a/lib/s3_store_errors.rb
+++ b/lib/s3_store_errors.rb
@@ -1,6 +1,6 @@
 
 # Note: Deriving S3StoreStandardError Class from Ruby's StandardError Class 
-# and further deriving S3Store Errors from S3StoreStandardError.
+# and further deriving all other application errors from S3StoreStandardError.
 
 class S3StoreStandardError < StandardError; end
 
@@ -17,3 +17,5 @@ class S3StoreEmptyBucketError < S3StoreStandardError; end
 class S3StoreEmptyError < S3StoreStandardError; end
 
 class S3ObjectCopyError < S3ObjectStandardError; end
+
+class S3ObjectOperationError < S3ObjectStandardError; end

--- a/lib/s3_store_errors.rb
+++ b/lib/s3_store_errors.rb
@@ -4,6 +4,8 @@
 
 class S3StoreStandardError < StandardError; end
 
+class S3ObjectStandardError < StandardError; end
+
 class S3StoreArgumentError < S3StoreStandardError; end
 
 class S3StoreInvalidArgumentError < S3StoreArgumentError; end
@@ -13,3 +15,5 @@ class S3StoreNoServiceError < S3StoreStandardError; end
 class S3StoreEmptyBucketError < S3StoreStandardError; end
 
 class S3StoreEmptyError < S3StoreStandardError; end
+
+class S3ObjectCopyError < S3ObjectStandardError; end

--- a/lib/store.rb
+++ b/lib/store.rb
@@ -23,7 +23,7 @@ class Store
           "S3StoreEmptyError :: You don't seem to have any buckets in your linked AWS S3 account. You may create one by using the command :: ".colorize(:light_blue) + " bin/s3_store_server create <bucket-name>".colorize(:yellow).bold if no_buckets?(response)
 
       bucket_names = response.buckets.map(&:name)
-      bucket_names.each { |name| puts name.colorize(:yellow) }
+      bucket_names
   end
 
   def no_buckets?(response)


### PR DESCRIPTION
This PR deals with being able to copy files and s3 objects. This feature handles 4 scenarios - 
1. Copy from one s3 bucket to another s3 bucket - Copy
2. Copy from local to s3 bucket - upload
3. Copy from s3 bucket to local - download
4. Copy from local to local - local copy

All methods used are provided by the aws-sdk-s3 gem for v3.

Each scenario works as explained below - 

1. **Copy from one s3 bucket to another s3 bucket** - While copying objects from one bucket to another, s3_store uses the `copy_object` method. It requires the _source bucket name, destination bucket name_ and _key._

Command Line example - 
```
bin/s3_store_server copy bucket-1 key:"file_2" source:"file_1" destination:"bucket-2"                         
```

2. **Copy from local to s3 bucket - upload** - While copying objects from local to s3 bucket, s3_store uses the `upload_file` method. It requires the _source file path, destination bucket name_ and _key_.

Command Line example - 
```
bin/s3_store_server copy bucket-1 key:<key_name> source:<full_path_to_local_file> destination:bucket-1
```

4. **Copy from local to local - not supported** - While copying objects from local to local, s3_store will raise an error `S3ObjectOperationError`. 
